### PR TITLE
Reachable and Unreachable assertion messages are no longer set to anonymous

### DIFF
--- a/tools/antithesis-go-instrumentor/assertions/assertion_hints.go
+++ b/tools/antithesis-go-instrumentor/assertions/assertion_hints.go
@@ -6,6 +6,7 @@ type AssertionFuncInfo struct {
 	Expecting  bool
 	AssertType string
 	Condition  bool
+  MessageArg int
 }
 
 type AssertionHints map[string]*AssertionFuncInfo
@@ -19,6 +20,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "every",
 		Condition:  false,
+    MessageArg: 1,
 	}
 
 	hintMap["AlwaysOrUnreachable"] = &AssertionFuncInfo{
@@ -27,6 +29,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "every",
 		Condition:  false,
+    MessageArg: 1,
 	}
 
 	hintMap["Sometimes"] = &AssertionFuncInfo{
@@ -35,6 +38,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "some",
 		Condition:  false,
+    MessageArg: 1,
 	}
 
 	hintMap["Unreachable"] = &AssertionFuncInfo{
@@ -43,6 +47,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "none",
 		Condition:  true,
+    MessageArg: 0,
 	}
 
 	hintMap["Reachable"] = &AssertionFuncInfo{
@@ -51,6 +56,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "none",
 		Condition:  true,
+    MessageArg: 0,
 	}
 	return hintMap
 }

--- a/tools/antithesis-go-instrumentor/assertions/assertion_hints.go
+++ b/tools/antithesis-go-instrumentor/assertions/assertion_hints.go
@@ -6,7 +6,7 @@ type AssertionFuncInfo struct {
 	Expecting  bool
 	AssertType string
 	Condition  bool
-  MessageArg int
+	MessageArg int
 }
 
 type AssertionHints map[string]*AssertionFuncInfo
@@ -20,7 +20,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "every",
 		Condition:  false,
-    MessageArg: 1,
+		MessageArg: 1,
 	}
 
 	hintMap["AlwaysOrUnreachable"] = &AssertionFuncInfo{
@@ -29,7 +29,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "every",
 		Condition:  false,
-    MessageArg: 1,
+		MessageArg: 1,
 	}
 
 	hintMap["Sometimes"] = &AssertionFuncInfo{
@@ -38,7 +38,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "some",
 		Condition:  false,
-    MessageArg: 1,
+		MessageArg: 1,
 	}
 
 	hintMap["Unreachable"] = &AssertionFuncInfo{
@@ -47,7 +47,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "none",
 		Condition:  true,
-    MessageArg: 0,
+		MessageArg: 0,
 	}
 
 	hintMap["Reachable"] = &AssertionFuncInfo{
@@ -56,7 +56,7 @@ func SetupHintMap() AssertionHints {
 		Expecting:  true,
 		AssertType: "none",
 		Condition:  true,
-    MessageArg: 0,
+		MessageArg: 0,
 	}
 	return hintMap
 }

--- a/tools/antithesis-go-instrumentor/assertions/assertion_scanner.go
+++ b/tools/antithesis-go-instrumentor/assertions/assertion_scanner.go
@@ -189,7 +189,7 @@ func (aScanner *AssertionScanner) node_inspector(x ast.Node) bool {
 			expr_text := analyzed_expr(aScanner.imports, sel_expr.X)
 			target_func := sel_expr.Sel.Name
 			if func_hints := aScanner.assertionHintMap.HintsForName(target_func); func_hints != nil && expr_text != "" {
-				test_name := arg_at_index(call_args, 1)
+				test_name := arg_at_index(call_args, func_hints.MessageArg)
 				expect := AntExpect{
 					Assertion:         target_func,
 					Message:           test_name,

--- a/tools/antithesis-go-instrumentor/cmd/cmd_args.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_args.go
@@ -24,7 +24,6 @@ type CommandArgs struct {
 	catalogDir          string
 	inputDir            string
 	outputDir           string
-	instrumentorVersion string
 }
 
 func ParseArgs(versionText string) *CommandArgs {
@@ -35,7 +34,6 @@ func ParseArgs(versionText string) *CommandArgs {
 	verbosePtr := flag.Int("V", 0, "verbosity level (default to 0)")
 	assertOnlyPtr := flag.Bool("assert_only", false, "generate assertion catalog ONLY - no coverage instrumentation (default to false)")
 	catalogDirPtr := flag.String("catalog_dir", "", "file path where assertion catalog will be generated")
-	instrVersionPtr := flag.String("instrumentor_version", "latest", "version of the SDK instrumentation package to require")
 	flag.Parse()
 
 	cmdArgs := CommandArgs{
@@ -52,7 +50,6 @@ func ParseArgs(versionText string) *CommandArgs {
 	cmdArgs.symPrefix = strings.TrimSpace(*prefixPtr)
 	cmdArgs.catalogDir = strings.TrimSpace(*catalogDirPtr)
 	cmdArgs.excludeFile = strings.TrimSpace(*exclusionsPtr)
-	cmdArgs.instrumentorVersion = strings.TrimSpace(*instrVersionPtr)
 
 	// Verify we have the expected number of positional arguments
 	numArgsRequired := 1
@@ -171,7 +168,6 @@ func (ca *CommandArgs) NewCommandFiles() (err error, cfx *CommandFiles) {
 		excludeFile:         ca.excludeFile,
 		wantsInstrumentor:   ca.wantsInstrumentor,
 		symtablePrefix:      symtablePrefix,
-		instrumentorVersion: ca.instrumentorVersion,
 		logWriter:           common.GetLogWriter(),
 	}
 	return

--- a/tools/antithesis-go-instrumentor/cmd/cmd_args.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_args.go
@@ -15,15 +15,15 @@ import (
 
 // Capitalized struct items are accessed outside this file
 type CommandArgs struct {
-	ShowVersion         bool
-	InvalidArgs         bool
-	logWriter           *common.LogWriter
-	excludeFile         string
-	symPrefix           string
-	wantsInstrumentor   bool
-	catalogDir          string
-	inputDir            string
-	outputDir           string
+	ShowVersion       bool
+	InvalidArgs       bool
+	logWriter         *common.LogWriter
+	excludeFile       string
+	symPrefix         string
+	wantsInstrumentor bool
+	catalogDir        string
+	inputDir          string
+	outputDir         string
 }
 
 func ParseArgs(versionText string) *CommandArgs {
@@ -160,15 +160,15 @@ func (ca *CommandArgs) NewCommandFiles() (err error, cfx *CommandFiles) {
 	catalogPath := filepath.Join(catalogDir, flattenedModuleName)
 
 	cfx = &CommandFiles{
-		outputDirectory:     outputDirectory,
-		inputDirectory:      customerInputDirectory,
-		customerDirectory:   customerDirectory,
-		symbolsDirectory:    symbolsDirectory,
-		catalogPath:         catalogPath,
-		excludeFile:         ca.excludeFile,
-		wantsInstrumentor:   ca.wantsInstrumentor,
-		symtablePrefix:      symtablePrefix,
-		logWriter:           common.GetLogWriter(),
+		outputDirectory:   outputDirectory,
+		inputDirectory:    customerInputDirectory,
+		customerDirectory: customerDirectory,
+		symbolsDirectory:  symbolsDirectory,
+		catalogPath:       catalogPath,
+		excludeFile:       ca.excludeFile,
+		wantsInstrumentor: ca.wantsInstrumentor,
+		symtablePrefix:    symtablePrefix,
+		logWriter:         common.GetLogWriter(),
 	}
 	return
 }

--- a/tools/antithesis-go-instrumentor/cmd/cmd_files.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_files.go
@@ -85,9 +85,6 @@ type CommandFiles struct {
 	// list.
 	filesSkipped int
 
-	// The version of SDK to use at runtime for CoverageInstrumentation
-	instrumentorVersion string
-
 	// Global logger
 	logWriter *common.LogWriter
 }
@@ -136,9 +133,6 @@ func (cfx *CommandFiles) WrapUp() {
 	if !cfx.wantsInstrumentor {
 		return
 	}
-	// Dependencies will just be the Antithesis SDK
-	// common.AddDependencies(cfx.inputDirectory, cfx.customerDirectory, cfx.instrumentorVersion)
-	// cfx.logWriter.Printf("Antithesis dependencies added to %s/go.mod", cfx.customerDirectory)
 
 	common.CopyRecursiveNoClobber(cfx.inputDirectory, cfx.customerDirectory)
 	cfx.logWriter.Printf("All other files copied unmodified from %s to %s", cfx.inputDirectory, cfx.customerDirectory)

--- a/tools/antithesis-go-instrumentor/common/files.go
+++ b/tools/antithesis-go-instrumentor/common/files.go
@@ -50,13 +50,13 @@ func CopyRecursiveNoClobber(from, to string) {
 	cmd := exec.Command("bash", "-c", commandLine)
 	logWriter.Printf("Executing %s", commandLine)
 	allOutput, err := cmd.CombinedOutput()
-  allText := strings.TrimSpace(string(allOutput))
-  lines := strings.Split(allText, "\n")
-  for _, line := range lines {
-    logWriter.Printf("cp: %s", line)
-  }
+	allText := strings.TrimSpace(string(allOutput))
+	lines := strings.Split(allText, "\n")
+	for _, line := range lines {
+		logWriter.Printf("cp: %s", line)
+	}
 	if err != nil {
-    logWriter.Printf("Ignoring cp exit code: %+v", err)
+		logWriter.Printf("Ignoring cp exit code: %+v", err)
 	}
 }
 

--- a/tools/antithesis-go-instrumentor/common/files.go
+++ b/tools/antithesis-go-instrumentor/common/files.go
@@ -60,21 +60,6 @@ func CopyRecursiveNoClobber(from, to string) {
 	}
 }
 
-// func AddDependencies(customerInputDirectory, customerOutputDirectory, instrumentorVersion string) {
-// 	commandLine := fmt.Sprintf("(cd %s; go mod edit -require=github.com/antithesishq/antithesis-sdk-go/instrumentation@%s -print > %s/go.mod)",
-// 		customerInputDirectory,
-// 		instrumentorVersion,
-// 		customerOutputDirectory)
-// 
-// 	cmd := exec.Command("bash", "-c", commandLine)
-// 	logWriter.Printf("Executing %s", commandLine)
-// 	_, err := cmd.Output()
-// 	if err != nil {
-// 		// Errors here are pretty mysterious.
-// 		logWriter.Fatalf("%v", err)
-// 	}
-// }
-
 // GetAbsoluteDirectory converts a path, whether a symlink or
 // a relative path, into an absolute path.
 func GetAbsoluteDirectory(path string) string {

--- a/tools/antithesis-go-instrumentor/version.txt
+++ b/tools/antithesis-go-instrumentor/version.txt
@@ -1,1 +1,1 @@
-Antithesis LLC Go Instrumentor v1.1.6, 2024-02-20
+Antithesis LLC Go Instrumentor v1.1.7, 2024-02-22


### PR DESCRIPTION
The message parameter was previously always the first parameter for all assertions.  When the condition and message parameter sequence was changed, this was no longer true.  Now the parameter that refers to the message is always explicitly tracked in the AssertionHints.

Removed instrumentation_version parameter which is no longer needed