### PR TITLE
New wrapup sequence for cmd_files independent of assertion wrapup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+result-*

--- a/default.nix
+++ b/default.nix
@@ -57,7 +57,7 @@ let
 
   go_sdk = pkgs.buildGoModule {
     pname = "antithesis-go-sdk";
-    version = "v0.2.9";
+    version = "v0.2.10";
 
     src = ./.;
 

--- a/tools/antithesis-go-instrumentor/antithesis-go-instrumentor.go
+++ b/tools/antithesis-go-instrumentor/antithesis-go-instrumentor.go
@@ -77,13 +77,16 @@ func main() {
 	// Wrap-up processing and generate assertions catalog and notifier module
 	//--------------------------------------------------------------------------------
 	edge_count := cI.WrapUp()
-	notifierDir := cmd_files.GetNotifierDirectory()
+	if edge_count > 0 {
+		notifierDir := cmd_files.GetNotifierDirectory()
+		cI.WriteNotifierSource(notifierDir, edge_count)
+		cmd_files.CreateNotifierModule()
+	}
 
-	aScanner.WriteAssertionCatalog()
-	cI.WriteNotifierSource(notifierDir, edge_count)
-
-	cmd_files.CreateNotifierModule()
-	cmd_files.WrapUp(aScanner.HasAssertionsDefined())
+	if aScanner.HasAssertionsDefined() {
+		aScanner.WriteAssertionCatalog()
+	}
+	cmd_files.WrapUp()
 
 	//--------------------------------------------------------------------------------
 	// Summarize results in logger


### PR DESCRIPTION
New wrapup sequence for cmd_files independent of assertion wrapup
Only create an assertion catalog when there are assertions
By default, exclude testdata directories from instrumentation