### PR TITLE
Enable notifier creation with local SDK dependency

### DIFF
--- a/tools/antithesis-go-instrumentor/cmd/cmd_args.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_args.go
@@ -22,6 +22,7 @@ type CommandArgs struct {
 	inputDir            string
 	outputDir           string
 	instrumentorVersion string
+	localSDKPath        string
 	ShowVersion         bool
 	InvalidArgs         bool
 	wantsInstrumentor   bool
@@ -36,6 +37,7 @@ func ParseArgs(versionText string) *CommandArgs {
 	assertOnlyPtr := flag.Bool("assert_only", false, "generate assertion catalog ONLY - no coverage instrumentation (default to false)")
 	catalogDirPtr := flag.String("catalog_dir", "", "file path where assertion catalog will be generated")
 	instrVersionPtr := flag.String("instrumentor_version", "latest", "version of the SDK instrumentation package to require")
+	localSDKPathPtr := flag.String("local_sdk_path", "", "path to the local Antithesis SDK")
 	flag.Parse()
 
 	cmdArgs := CommandArgs{
@@ -53,6 +55,7 @@ func ParseArgs(versionText string) *CommandArgs {
 	cmdArgs.catalogDir = strings.TrimSpace(*catalogDirPtr)
 	cmdArgs.excludeFile = strings.TrimSpace(*exclusionsPtr)
 	cmdArgs.instrumentorVersion = strings.TrimSpace(*instrVersionPtr)
+	cmdArgs.localSDKPath = strings.TrimSpace(*localSDKPathPtr)
 
 	// Verify we have the expected number of positional arguments
 	numArgsRequired := 1
@@ -174,6 +177,7 @@ func (ca *CommandArgs) NewCommandFiles() (cfx *CommandFiles, err error) {
 		wantsInstrumentor:   ca.wantsInstrumentor,
 		symtablePrefix:      symtablePrefix,
 		instrumentorVersion: ca.instrumentorVersion,
+		localSDKPath:        ca.localSDKPath,
 		logWriter:           common.GetLogWriter(),
 	}
 	return

--- a/tools/antithesis-go-instrumentor/cmd/cmd_files.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_files.go
@@ -75,6 +75,9 @@ type CommandFiles struct {
 	// The version of SDK to use at runtime for CoverageInstrumentation
 	instrumentorVersion string
 
+	// The path to the SDK to use to create the notifier
+	localSDKPath string
+
 	// created and written to during instrumentation.
 	// Will contain the antithesis notifier module (go.mod) and source (notifier.go)
 	notifierDirectory string
@@ -148,9 +151,6 @@ func (cfx *CommandFiles) WrapUp() {
 
 	common.CopyRecursiveNoClobber(cfx.inputDirectory, cfx.customerDirectory)
 	cfx.logWriter.Printf("All other files copied unmodified from %s to %s", cfx.inputDirectory, cfx.customerDirectory)
-
-	common.FetchDependencies(cfx.customerDirectory)
-	cfx.logWriter.Printf("Downloaded and tidied Antithesis dependencies")
 }
 
 func (cfx *CommandFiles) WriteInstrumentedOutput(fileName string, instrumentedSource string, cI *instrumentor.CoverageInstrumentor) {
@@ -174,7 +174,7 @@ func (cfx *CommandFiles) CreateNotifierModule() {
 	notifierModuleName := common.NOTIFIER_MODULE_NAME
 
 	if cfx.wantsInstrumentor {
-		common.NotifierDependencies(cfx.notifierDirectory, notifierModuleName, cfx.instrumentorVersion)
+		common.NotifierDependencies(cfx.notifierDirectory, notifierModuleName, cfx.instrumentorVersion, cfx.localSDKPath)
 	}
 }
 

--- a/tools/antithesis-go-instrumentor/version.txt
+++ b/tools/antithesis-go-instrumentor/version.txt
@@ -1,1 +1,1 @@
-Antithesis LLC Go Instrumentor v1.2.1, 2024-03-01
+Antithesis LLC Go Instrumentor v0.2.11, 2024-03-05


### PR DESCRIPTION
Enable notifier creation with local SDK dependency (via Nix).
Adds new command line param `-local_sdk_path <path>` for instrumentor