### PR TITLE
Copy customer files before performing `go mod tidy`

### DIFF
--- a/tools/antithesis-go-instrumentor/cmd/cmd_files.go
+++ b/tools/antithesis-go-instrumentor/cmd/cmd_files.go
@@ -149,13 +149,13 @@ func (cfx *CommandFiles) WrapUp() {
 	common.AddDependencies(cfx.inputDirectory, cfx.customerDirectory, cfx.instrumentorVersion, notifierModule)
 	cfx.logWriter.Printf("Antithesis dependencies added to %s/go.mod", cfx.customerDirectory)
 
+	common.CopyRecursiveNoClobber(cfx.inputDirectory, cfx.customerDirectory)
+	cfx.logWriter.Printf("All other files copied unmodified from %s to %s", cfx.inputDirectory, cfx.customerDirectory)
+
 	if cfx.localSDKPath == "" {
 		common.FetchDependencies(cfx.customerDirectory)
 		cfx.logWriter.Printf("Downloaded Antithesis dependencies")
 	}
-
-	common.CopyRecursiveNoClobber(cfx.inputDirectory, cfx.customerDirectory)
-	cfx.logWriter.Printf("All other files copied unmodified from %s to %s", cfx.inputDirectory, cfx.customerDirectory)
 }
 
 func (cfx *CommandFiles) WriteInstrumentedOutput(fileName string, instrumentedSource string, cI *instrumentor.CoverageInstrumentor) {

--- a/tools/antithesis-go-instrumentor/version.txt
+++ b/tools/antithesis-go-instrumentor/version.txt
@@ -1,1 +1,1 @@
-Antithesis LLC Go Instrumentor v0.2.12, 2024-03-08
+Antithesis LLC Go Instrumentor v0.2.13


### PR DESCRIPTION
Do not perform optional go mod tidy until after all customer files are swept into the instrumented output directory