### PR TITLE
Specify antithesis_sdk build tag for doc2go

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 // This package is part of the [Antithesis Go SDK], which enables Go applications to integrate with the [Antithesis platform].
 //

--- a/assert/assert_noop.go
+++ b/assert/assert_noop.go
@@ -1,4 +1,4 @@
-//go:build !antithesis_sdk
+//go:build no_antithesis_sdk
 
 package assert
 

--- a/assert/location.go
+++ b/assert/location.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 package assert
 

--- a/assert/tracker.go
+++ b/assert/tracker.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 package assert
 

--- a/default.nix
+++ b/default.nix
@@ -50,14 +50,14 @@ let
       export HOME=$TMPDIR
       mkdir -p $out/docs
       # TODO: can add `-emded` to generate basic stubs for the docs with no styling to customize our own
-      doc2go -home github.com/antithesishq/antithesis-sdk-go -tags antithesis_sdk -out $out/docs ./assert ./random ./lifecycle
+      doc2go -home github.com/antithesishq/antithesis-sdk-go -out $out/docs ./assert ./random ./lifecycle
       pandoc --template ${index_template} -o $out/index.html README.md
     '';
   };
 
   go_sdk = pkgs.buildGoModule {
     pname = "antithesis-go-sdk";
-    version = "v0.3.1";
+    version = "v0.3.3";
 
     src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,7 @@ let
       export HOME=$TMPDIR
       mkdir -p $out/docs
       # TODO: can add `-emded` to generate basic stubs for the docs with no styling to customize our own
-      doc2go -home github.com/antithesishq/antithesis-sdk-go -out $out/docs ./assert ./random ./lifecycle
+      doc2go -home github.com/antithesishq/antithesis-sdk-go -tags antithesis_sdk -out $out/docs ./assert ./random ./lifecycle
       pandoc --template ${index_template} -o $out/index.html README.md
     '';
   };

--- a/instrumentation/notify.go
+++ b/instrumentation/notify.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 package instrumentation
 

--- a/instrumentation/notify_noop.go
+++ b/instrumentation/notify_noop.go
@@ -1,4 +1,4 @@
-//go:build !antithesis_sdk
+//go:build no_antithesis_sdk
 
 package instrumentation
 

--- a/internal/emit.go
+++ b/internal/emit.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 package internal
 

--- a/internal/emit_test.go
+++ b/internal/emit_test.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 package internal
 

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 // This package is part of the [Antithesis Go SDK], which enables Go applications to integrate with the [Antithesis platform].
 //

--- a/lifecycle/lifecycle_noop.go
+++ b/lifecycle/lifecycle_noop.go
@@ -1,4 +1,4 @@
-//go:build !antithesis_sdk
+//go:build no_antithesis_sdk
 
 package lifecycle
 

--- a/random/random.go
+++ b/random/random.go
@@ -1,4 +1,4 @@
-//go:build antithesis_sdk
+//go:build !no_antithesis_sdk
 
 // This package is part of the [Antithesis Go SDK], which enables Go applications to integrate with the [Antithesis platform].
 //


### PR DESCRIPTION
Specify `-tags=antithesis_sdk` command line option for `doc2go` to ensure the non-stubbed version of sdk functions are included in the generated docs