### PR TITLE
Fix bug with instrumentor cp command not working on macos

### DIFF
--- a/tools/antithesis-go-instrumentor/common/files.go
+++ b/tools/antithesis-go-instrumentor/common/files.go
@@ -46,7 +46,7 @@ func WriteTextFile(text, file_name string) (err error) {
 }
 
 func CopyRecursiveNoClobber(from, to string) {
-	commandLine := fmt.Sprintf("cp -v --no-clobber --recursive %s/* %s", from, to)
+	commandLine := fmt.Sprintf("cp -v -n -R %s/* %s", from, to)
 	cmd := exec.Command("bash", "-c", commandLine)
 	logWriter.Printf("Executing %s", commandLine)
 	allOutput, err := cmd.CombinedOutput()


### PR DESCRIPTION
MacOS uses BSD `cp` and does not support descriptive flag names such as `--no-clobber` and `--recursive`. I've updated the command to support both Linux and MacOS.