### PR TITLE
Add generic version of RandomChoice

### DIFF
--- a/random/random_choice.go
+++ b/random/random_choice.go
@@ -13,3 +13,18 @@ func RandomChoice(things []any) any {
 	index := uval % uint64(num_things)
 	return things[index]
 }
+
+// RandomChoiceG is the generic version of RandomChoice (usable, for example, with a list of strings, integers, etc.).
+//
+// Refer to the RandomChoice documentation for important additional information about this method.
+func RandomChoiceG[T any](things []T) T {
+	numThings := len(things)
+	if numThings == 0 {
+		var nullThing T
+		return nullThing
+	}
+
+	uval := GetRandom()
+	index := uval % uint64(numThings)
+	return things[index]
+}

--- a/random/random_choice_test.go
+++ b/random/random_choice_test.go
@@ -1,0 +1,33 @@
+package random
+
+import (
+	"testing"
+)
+
+func TestRandomChoice(t *testing.T) {
+	type Thing struct {
+		chosenCount int
+	}
+
+	choices := []any{
+		&Thing{},
+		&Thing{},
+		&Thing{},
+		&Thing{},
+		&Thing{},
+	}
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		chosen := RandomChoice(choices)
+		chosen.(*Thing).chosenCount += 1
+	}
+
+	for i, anything := range choices {
+		thing := anything.(*Thing)
+		t.Logf("Thing %d/%d was chosen %d times", i+1, len(choices), thing.chosenCount)
+		if thing.chosenCount == 0 {
+			t.Fatalf("Some element was never chosen in %d random choices!", N)
+		}
+	}
+}

--- a/random/random_choice_test.go
+++ b/random/random_choice_test.go
@@ -31,3 +31,30 @@ func TestRandomChoice(t *testing.T) {
 		}
 	}
 }
+
+func TestRandomChoiceGeneric(t *testing.T) {
+
+	choices := []string{
+		"Hello",
+		"World",
+		"How",
+		"Are",
+		"You",
+		"?",
+	}
+
+	counts := make(map[string]int)
+	const N = 100
+	for i := 0; i < N; i++ {
+		chosen := RandomChoiceG(choices)
+		counts[chosen] += 1
+	}
+
+	for i, s := range choices {
+		count, present := counts[s]
+		t.Logf("Item %d/%d was chosen %d times", i+1, len(choices), count)
+		if !present {
+			t.Fatalf("Some element was never chosen in %d random choices!", N)
+		}
+	}
+}


### PR DESCRIPTION
`RandomChoice` does not accept lists of strings, numbers, and other non-interface types.

This commit adds a generic variant `RandomChoiceG` that accepts any collection (of a single type), useful for choosing a random string or number in a set of options.

Also add simple tests for both the original method and the new one.
